### PR TITLE
Add and Update Stats Cards Component

### DIFF
--- a/components/ProfileForm/Stats.tsx
+++ b/components/ProfileForm/Stats.tsx
@@ -1,0 +1,171 @@
+"use client"
+
+import React, { useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import { Switch } from '../ui/switch'
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '../ui/select'
+
+const Themes = [
+    "default",
+    "dark",
+    "radical",
+    "merko",
+    "gruvbox",
+    "tokyonight",
+    "onedark",
+    "cobalt",
+    "synthwave",
+    "highcontrast",
+    "dracula",
+    "prussian",
+    "monokai",
+    "vue",
+    "vue-dark",
+    "shades-of-purple",
+    "nightowl",
+    "buefy",
+    "blue-green",
+    "algolia",
+    "great-gatsby",
+    "darcula",
+    "bear",
+    "solarized-dark",
+    "solarized-light",
+    "chartreuse-dark",
+    "nord",
+    "gotham",
+    "material-palenight",
+    "graywhite",
+    "vision-friendly-dark",
+    "ayu-mirage",
+    "midnight-purple",
+    "calm",
+    "flag-india",
+    "omni",
+    "react",
+    "jolly",
+    "maroongold",
+    "yeblu",
+    "blueberry",
+    "slateorange",
+    "kacho_ga",
+    "outrun",
+    "ocean_dark",
+    "city_lights",
+    "github_dark",
+    "discord_old_blurple",
+    "aura_dark",
+    "panda",
+    "noctis_minimus",
+    "cobalt2",
+    "swift",
+    "aura",
+    "apprentice",
+    "moltack",
+    "codeSTACKr",
+    "rose_pine",
+]
+
+const Stats = () => {
+    const [showIcons, setShowIcons] = useState(true)
+    const [theme, setTheme] = useState("radical")
+    const [streakTheme, setStreakTheme] = useState("default")
+    const [langTheme, setLangTheme] = useState("default")
+    const [trophyTheme, setTrophyTheme] = useState("default")
+    const [profileTheme, setProfileTheme] = useState("default")
+    const [wakatimeTheme, setWakatimeTheme] = useState("default")
+    const [contributionTheme, setContributionTheme] = useState("default")
+
+    const username = "sushilmagare10"
+
+    return (
+        <Card className='w-full flex flex-col p-0 border-none gap-4 '>
+            <CardTitle>GitHub Stats for {username}</CardTitle>
+            <CardContent className='p-0 flex flex-col gap-4'>
+                <StatCard
+                    title="GitHub Stats"
+                    src={`https://github-readme-stats.vercel.app/api?username=${username}&show_icons=${showIcons}&theme=${theme}`}
+                    showIcons={showIcons}
+                    setShowIcons={setShowIcons}
+                    selectedTheme={theme}
+                    setSelectedTheme={setTheme}
+                    themes={Themes}
+                />
+                <StatCard
+                    title="GitHub Streak Stats"
+                    src={`https://github-readme-streak-stats.herokuapp.com/?user=${username}&theme=${streakTheme}`}
+                    selectedTheme={streakTheme}
+                    setSelectedTheme={setStreakTheme}
+                    themes={Themes}
+                />
+                <StatCard
+                    title="Top Languages"
+                    src={`https://github-readme-stats.vercel.app/api/top-langs/?username=${username}&layout=compact&theme=${langTheme}`}
+                    selectedTheme={langTheme}
+                    setSelectedTheme={setLangTheme}
+                    themes={Themes}
+                />
+                <StatCard
+                    title="GitHub Trophies"
+                    src={`https://github-profile-trophy.vercel.app/?username=${username}&theme=${trophyTheme}`}
+                    selectedTheme={trophyTheme}
+                    setSelectedTheme={setTrophyTheme}
+                    themes={Themes}
+                />
+                <StatCard
+                    title="Profile Details"
+                    src={`https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=${username}&theme=${profileTheme}`}
+                    selectedTheme={profileTheme}
+                    setSelectedTheme={setProfileTheme}
+                    themes={Themes}
+                />
+                <StatCard
+                    title="Wakatime Stats"
+                    src={`https://github-readme-stats.vercel.app/api/wakatime?username=${username}&layout=compact&theme=${wakatimeTheme}`}
+                    selectedTheme={wakatimeTheme}
+                    setSelectedTheme={setWakatimeTheme}
+                    themes={Themes}
+                />
+                <StatCard
+                    title="GitHub Contribution Graph"
+                    src={`https://activity-graph.herokuapp.com/graph?username=${username}&theme=${contributionTheme}`}
+                    selectedTheme={contributionTheme}
+                    setSelectedTheme={setContributionTheme}
+                    themes={Themes}
+                />
+            </CardContent>
+        </Card>
+    )
+}
+
+const StatCard = ({ title, src, showIcons, setShowIcons, selectedTheme, setSelectedTheme, themes }) => (
+    <Card className='rounded-sm flex justify-betweenv p-0 items-center gap-1 h-60'>
+        <CardContent className='flex flex-col flex-[2] h-full px-2 py-0'>
+            <CardHeader className='p-0 font-semibold text-primary mt-2'>{title}</CardHeader>
+            <img src={src} alt={title} className='mt-4 h-56 w-full' />
+        </CardContent>
+        <CardContent className=' flex-1 mt-4'>
+            {setShowIcons && (
+                <div className='flex justify-between items-center gap-1'>
+                    <label>Show Icons</label>
+                    <Switch checked={showIcons} onCheckedChange={setShowIcons} className='border-black/10' />
+                </div>
+            )}
+            <Select value={selectedTheme} onValueChange={setSelectedTheme}>
+                <SelectTrigger className="w-full mt-2">
+                    <SelectValue placeholder="Select a Theme" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectGroup>
+                        <SelectLabel>Themes</SelectLabel>
+                        {themes.map(theme => (
+                            <SelectItem key={theme} value={theme}>{theme.charAt(0).toUpperCase() + theme.slice(1)}</SelectItem>
+                        ))}
+                    </SelectGroup>
+                </SelectContent>
+            </Select>
+        </CardContent>
+    </Card>
+)
+
+export default Stats

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted/50 p-1 text-muted-foreground",
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted/20 p-1 text-muted-foreground",
       className
     )}
     {...props}


### PR DESCRIPTION
### Summary:
This pull request introduces the Stats.tsx component, which includes various GitHub and Wakatime statistics cards. It also adds a new Switch component and updates the Tabs component. The new Stats component allows users to view and customize multiple types of statistics with selectable themes.

**Changes:**

**1. New Component - Stats.tsx:**
- Added a new Stats component to display various GitHub and Wakatime statistics.
- The component includes multiple StatCard elements for different types of statistics:
   - GitHub Stats
   - GitHub Streak Stats
   - Top Languages
   - GitHub Trophies
   - Profile Details
   - Wakatime Stats
   - GitHub Contribution Graph
- Users can toggle the display of icons and select themes for each card.

**2. New Component - Switch.tsx:**
- Introduced a Switch component for toggling the display of icons in the Stats component.
- The switch leverages Radix UI's Switch primitives for enhanced accessibility and styling.

**3. Updated Component - Tabs.tsx:**
- Made minor adjustments to the Tabs component to refine styling and improve consistency.

**Screenshot:**

![stats](https://github.com/user-attachments/assets/8231e791-885c-4785-81da-b6b4e26b7cca)
