### PR TITLE
Removed GitHub Icons and Update Support Data

### DIFF
--- a/components/ProfileForm/Support.tsx
+++ b/components/ProfileForm/Support.tsx
@@ -41,7 +41,6 @@ const Support = () => {
                         <SelectContent>
                             <SelectItem value="shieldIcons">Shields Icons</SelectItem>
                             <SelectItem value="simpleIcons">Simple Icons</SelectItem>
-                            <SelectItem value="githubRaw">GitHub Raw Icons</SelectItem>
                         </SelectContent>
                     </Select>
                     {selectedProvider === 'shieldIcons' && (

--- a/data/SupportData.ts
+++ b/data/SupportData.ts
@@ -35,6 +35,60 @@ export const SupportData = {
             label: "Flattr",
             url: "https://img.shields.io/badge/Flattr-0074E4?logo=flattr&logoColor=white",
             href: (username: string) => `https://flattr.com/profile/${username}`
+        },
+        {
+            id: "gumroad",
+            label: "Gumroad",
+            url: "https://img.shields.io/badge/Gumroad-36a9ae?logo=gumroad&logoColor=white",
+            href: (username: string) => `https://gumroad.com/${username}`
+        },
+        {
+            id: "substack",
+            label: "Substack",
+            url: "https://img.shields.io/badge/Substack-ff6719?logo=substack&logoColor=white",
+            href: (username: string) => `https://substack.com/profile/${username}`
+        },
+        {
+            id: "paytm",
+            label: "Paytm",
+            url: "https://img.shields.io/badge/Paytm-002970?logo=paytm&logoColor=white",
+            href: (username: string) => `https://paytm.com/${username}`
+        },
+        {
+            id: "googlepay",
+            label: "Google Pay",
+            url: "https://img.shields.io/badge/Google%20Pay-4285F4?logo=googlepay&logoColor=white",
+            href: (username: string) => `https://pay.google.com/${username}`
+        },
+        {
+            id: "razorpay",
+            label: "Razorpay",
+            url: "https://img.shields.io/badge/Razorpay-02042B?logo=razorpay&logoColor=white",
+            href: (username: string) => `https://razorpay.com/${username}`
+        },
+        {
+            id: "venmo",
+            label: "Venmo",
+            url: "https://img.shields.io/badge/Venmo-3D95CE?logo=venmo&logoColor=white",
+            href: (username: string) => `https://venmo.com/${username}`
+        },
+        {
+            id: "cashapp",
+            label: "Cash App",
+            url: "https://img.shields.io/badge/Cash%20App-00C244?logo=cashapp&logoColor=white",
+            href: (username: string) => `https://cash.app/${username}`
+        },
+        {
+            id: "square",
+            label: "Square",
+            url: "https://img.shields.io/badge/Square-3E4348?logo=square&logoColor=white",
+            href: (username: string) => `https://squareup.com/${username}`
+        },
+        {
+            id: "stripe",
+            label: "Stripe",
+            url: "https://img.shields.io/badge/Stripe-008CDD?logo=stripe&logoColor=white",
+            href: (username: string) => `https://stripe.com/${username}`
         }
     ],
     "simpleIcons": [
@@ -53,13 +107,13 @@ export const SupportData = {
         {
             id: "simple-icons-buymeacoffee",
             label: "Buy Me a Coffee",
-            url: "https://simpleicons.org/icons/buymeacoffee.svg",
+            url: "https://cdn.simpleicons.org/buymeacoffee/FFDD00",
             href: (username: string) => `https://buymeacoffee.com/${username}`
         },
         {
             id: "simple-icons-paypal",
             label: "PayPal",
-            url: "https://img.simpleicons.org/paypal/00457C?logo=paypal&logoColor=white",
+            url: "https://cdn.simpleicons.org/paypal/003087",
             href: (username: string) => `https://paypal.me/${username}`
         },
         {
@@ -73,6 +127,60 @@ export const SupportData = {
             label: "Flattr",
             url: "https://img.simpleicons.org/flattr/0074E4?logo=flattr&logoColor=white",
             href: (username: string) => `https://flattr.com/profile/${username}`
+        },
+        {
+            id: "simple-icons-gumroad",
+            label: "Gumroad",
+            url: "https://img.simpleicons.org/gumroad/36a9ae?logo=gumroad&logoColor=white",
+            href: (username: string) => `https://gumroad.com/${username}`
+        },
+        {
+            id: "simple-icons-substack",
+            label: "Substack",
+            url: "https://img.simpleicons.org/substack/ff6719?logo=substack&logoColor=white",
+            href: (username: string) => `https://substack.com/profile/${username}`
+        },
+        {
+            id: "simple-icons-paytm",
+            label: "Paytm",
+            url: "https://img.simpleicons.org/paytm/002970?logo=paytm&logoColor=white",
+            href: (username: string) => `https://paytm.com/${username}`
+        },
+        {
+            id: "simple-icons-googlepay",
+            label: "Google Pay",
+            url: "https://img.simpleicons.org/googlepay/4285F4?logo=googlepay&logoColor=white",
+            href: (username: string) => `https://pay.google.com/${username}`
+        },
+        {
+            id: "simple-icons-razorpay",
+            label: "Razorpay",
+            url: "https://img.simpleicons.org/razorpay/02042B?logo=razorpay&logoColor=white",
+            href: (username: string) => `https://razorpay.com/${username}`
+        },
+        {
+            id: "simple-icons-venmo",
+            label: "Venmo",
+            url: "https://img.simpleicons.org/venmo/3D95CE?logo=venmo&logoColor=white",
+            href: (username: string) => `https://venmo.com/${username}`
+        },
+        {
+            id: "simple-icons-cashapp",
+            label: "Cash App",
+            url: "https://img.simpleicons.org/cashapp/00C244?logo=cashapp&logoColor=white",
+            href: (username: string) => `https://cash.app/${username}`
+        },
+        {
+            id: "simple-icons-square",
+            label: "Square",
+            url: "https://img.simpleicons.org/square/3E4348?logo=square&logoColor=white",
+            href: (username: string) => `https://squareup.com/${username}`
+        },
+        {
+            id: "simple-icons-stripe",
+            label: "Stripe",
+            url: "https://img.simpleicons.org/stripe/008CDD?logo=stripe&logoColor=white",
+            href: (username: string) => `https://stripe.com/${username}`
         }
-    ],
-}
+    ]
+};


### PR DESCRIPTION
### Description
This pull request addresses the removal of GitHub icons for the support field and updates the support data to include new support icons from both the Shields.io and Simple Icons providers.

**Changes Made**

1. Components:

- I updated the Support component to remove the option to select GitHub Raw Icons.

2. Data:

- Removed GitHub-related icons from the SupportData structure.
- Added new support icons for various platforms including Flattr, Gumroad, Substack, Paytm, Google Pay, Razorpay, Venmo, Cash App, Square, and Stripe in both shieldIcons and simpleIcons.

**Files Changed**

- components/ProfileForm/Support.tsx:

- Removed GitHub Raw Icons from the select provider options.

**data/SupportData.ts:**

- Removed GitHub-related icons.
- Added new support icons for multiple platforms.