### PR TITLE
Added textarea for about me in the introduction and adjusted height for streak card

### DIFF
--- a/components/ProfileForm/Introduction.tsx
+++ b/components/ProfileForm/Introduction.tsx
@@ -11,6 +11,7 @@ import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
 import Link from 'next/link';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
+import { Textarea } from '../ui/textarea';
 
 type EmojiFieldType = 'name' | 'aboutMe' | 'learning' | 'askMeAbout' | 'funFact' | 'portfolio' | 'blog' | 'working';
 
@@ -55,14 +56,24 @@ const Introduction = () => {
         }
     };
 
-    const renderInput = (value: string, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void, placeholder: string, field: EmojiFieldType) => (
+    const renderInput = (value: string, onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void, placeholder: string, field: EmojiFieldType) => (
         <div className='flex justify-center items-center gap-2 relative'>
-            <Input
-                value={value}
-                onChange={onChange}
-                placeholder={placeholder}
-                className="w-full border-gray-300 rounded-md shadow-sm"
-            />
+            {field === 'aboutMe' ? (
+                <Textarea
+                    value={value}
+                    onChange={onChange}
+                    placeholder={placeholder}
+                    className="w-full border-gray-300 rounded-md shadow-sm"
+                    rows={5}
+                />
+            ) : (
+                <Input
+                    value={value}
+                    onChange={onChange}
+                    placeholder={placeholder}
+                    className="w-full border-gray-300 rounded-md shadow-sm"
+                />
+            )}
             <div className='flex flex-col gap-1 justify-between'>
                 <div className='text-2xl mb-1 cursor-pointer' onClick={() => toggleEmoji(field)} >
                     🙂

--- a/store/StatsCardStore.tsx
+++ b/store/StatsCardStore.tsx
@@ -145,7 +145,7 @@ const getDefaultProps = (type: CardType): Card => {
                 hide_longest_streak: false,
                 exclude_days: [],
                 locale: 'en',
-                card_height: 250
+                card_height: 200
             };
     }
 


### PR DESCRIPTION
### Description:
This pull request introduces the following changes:

**1. Textarea for About Me in Profile Form:**

- Modified the `renderInput `function to include a `Textarea `component for the "about me" field, allowing for multiline input.
- The `Textarea` is displayed with a height of 5 rows to provide users with more space for entering detailed information in the "about me" section.

**2. Fixed Height Adjustment for Streak Card:**

- Reduced the default height of the streak card from 250px to 200px for better visual balance.