### PR TITLE
Enhance GitHub Profile Generator: Add Customization Options and UI Improvements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -61,21 +61,18 @@
 }
 
 
-@layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}
-
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
 
 .scrollbar-hide {
   scrollbar-width: none;
+}
+
+.dropdown {
+    overflow-y: auto;
+    max-height: 380px;
+    will-change: scroll-position;
 }
 
 .ProseMirror {

--- a/components/MarkdownGenerator.tsx
+++ b/components/MarkdownGenerator.tsx
@@ -18,9 +18,12 @@ const MarkdownGenerator = () => {
   const [isCopied, setIsCopied] = useState(false);
   const { headerImage, name, aboutMe, currentlyDoing, fieldStyles, profileViews } = useIntroductionStore();
   const { gap, icons: socialIcons, sectionStyle, iconHeight: socialIconHeight } = useSocialStore();
-  const { icons: skillIcons, iconHeight: skillIconHeight, gap: skillIconsGap, alignment } = useSkillsStore();
+  const { icons: skillIcons, iconHeight: skillIconHeight, gap: skillIconsGap, alignment, layout: SkillLayout, selectedProvider } = useSkillsStore();
   const { gap: SupportIconGap, alignment: SupportAlignment, iconHeight: SupportIconsHeight, icons: SupportIcons } = useSupportStore();
   const { username, cards } = useStatsCardStore();
+
+  const isShieldsIO = selectedProvider === 'shields.io';
+  const iconsPerRow = isShieldsIO ? 6 : 12;
 
   const generateMarkdown = () => {
     let markdown = '';
@@ -86,12 +89,29 @@ const MarkdownGenerator = () => {
 
     if (skillIcons.length > 0) {
       markdown += ` **<h3 align="${alignment}">Skills</h3>**\n\n`;
-      markdown += `<p align="${alignment}">`;
-      markdown += skillIcons.map(icon =>
-        `<img src="${icon.url}" height="${heightValues[skillIconHeight]}" alt="${icon.label}" style="margin-right: ${gapValues[skillIconsGap]}px">`
-      ).join(' ');
-      markdown += '</p>\n\n';
+      if (SkillLayout === "Layout-1") {
+        markdown += `<div style="display: flex; flex-wrap: wrap; gap: ${gapValues[skillIconsGap]}px; justify-content: ${alignment};">`;
+        markdown += skillIcons.map(icon =>
+          `<img src="${icon.url}" height="${heightValues[skillIconHeight]}" alt="${icon.label}" style="margin-right: ${gapValues[skillIconsGap]}px">`
+        ).join(' ');
+        markdown += `</div>\n\n`;
+      } else if (SkillLayout === "Layout-2") {
+        markdown += `<table style="width: 100%; border: 0px solid white;">`;
+        skillIcons.forEach((icon, index) => {
+          if (index % iconsPerRow === 0) {
+            markdown += `<tr>`;
+          }
+          markdown += `<td style="text-align: center; border: 0px; padding: 12px;">`;
+          markdown += `<img src="${icon.url}" height="${heightValues[skillIconHeight]}" alt="${icon.label}"/>`;
+          markdown += `</td>`;
+          if (index % iconsPerRow === iconsPerRow - 1) {
+            markdown += `</tr>`;
+          }
+        });
+        markdown += `</table>\n\n`;
+      }
     }
+
 
     if (cards.length > 0) {
       markdown += ` **<h3 align="left">GitHub Stats</h3>**\n\n`;

--- a/components/ProfileForm/Introduction.tsx
+++ b/components/ProfileForm/Introduction.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { ReactNode, useState } from 'react';
-import { Card, CardContent, CardHeader } from '../ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import useIntroductionStore from '@/store/IntroStore';
@@ -12,6 +12,8 @@ import data from '@emoji-mart/data'
 import Link from 'next/link';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { Textarea } from '../ui/textarea';
+import { Banners } from '@/data/IntroData';
+
 
 type EmojiFieldType = 'name' | 'aboutMe' | 'learning' | 'askMeAbout' | 'funFact' | 'portfolio' | 'blog' | 'working';
 
@@ -92,6 +94,53 @@ const Introduction = () => {
         </div>
     );
 
+    const [openDropdown, setOpenDropdown] = useState<string | null>(null);
+
+    const toggleDropdown = (dropdown: string) => {
+        setOpenDropdown(prev => prev === dropdown ? null : dropdown);
+    };
+
+    const handleBannerSelect = (banner: string, setter: (banner: string) => void) => {
+        setOpenDropdown(null);
+        setter(banner);
+    };
+
+
+    const renderBannerOptions = (banners: (string | undefined)[], handleSelect: (banner: string) => void, dropdownKey: string) => (
+        <CardContent className='p-0'>
+            <div className="relative">
+                <button
+                    onClick={() => toggleDropdown(dropdownKey)}
+                    className="w-full bg-white border border-gray-300 rounded-md shadow-sm px-4 py-2 text-left"
+                >
+                    Select a banner
+                </button>
+                {openDropdown === dropdownKey && (
+                    <div className="absolute z-10 mt-2 w-full bg-white border border-gray-300 rounded-md shadow-lg">
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 max-h-96 scrollbar-hide dropdown">
+                            {banners.map((item: string | undefined, index: number) => (
+                                item ? (
+                                    <div key={index} onClick={() => handleSelect(item)} className="cursor-pointer flex flex-col items-center">
+                                        <img
+                                            src={item}
+                                            alt={`Banner ${index + 1}`}
+                                            className="w-48 h-24 object-cover rounded-md"
+                                            loading="lazy"
+                                            width="192"
+                                            height="96"
+                                        />
+                                    </div>
+                                ) : null
+                            ))}
+
+                        </div>
+                    </div>
+                )}
+            </div>
+        </CardContent>
+    );
+
+
     return (
         <Card className='w-full h-full flex flex-col border-none'>
             <div className='space-y-8 h-max pb-40 lg:pb-4'>
@@ -99,7 +148,7 @@ const Introduction = () => {
                     title="Add Header Image"
                     icon={<FaImage className="text-blue-600 text-xl" />}
                 >
-                    <div className=' w-full flex justify-between items-center '>
+                    <div className=' w-full flex justify-between items-center mb-2'>
                         <span className='flex flex-col md:flex-row justify-between items-center gap-2'>To create custom Header use this
                             <Link
                                 href='https://leviarista.github.io/github-profile-header-generator'
@@ -124,6 +173,9 @@ const Introduction = () => {
                     </div>
                     <Card className='w-full border border-gray-300 rounded-md shadow-sm '>
                         <CardHeader className="text-lg font-semibold ">Image URL</CardHeader>
+                        <CardContent>
+                            {renderBannerOptions(Banners, setHeaderImage, 'headerBanner')}
+                        </CardContent>
                         <CardContent>
                             <Input
                                 placeholder='https://example.com/image.jpg'
@@ -219,7 +271,7 @@ type SectionType = {
     children: ReactNode;
 };
 
-const Section = ({ title, icon, children }: SectionType) => (
+const Section = React.memo(({ title, icon, children }: SectionType) => (
     <div className='w-full'>
         <div className='flex items-center space-x-3 mb-4'>
             <Label className="text-xl font-semibold flex items-center space-x-2 ">
@@ -229,6 +281,8 @@ const Section = ({ title, icon, children }: SectionType) => (
         </div>
         {children}
     </div>
-)
+));
+
+Section.displayName = 'Section';
 
 export default Introduction;

--- a/components/ProfileForm/Skills.tsx
+++ b/components/ProfileForm/Skills.tsx
@@ -8,6 +8,7 @@ import { SkillsData } from '@/data/SkillsData';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import useSkillsStore from '@/store/SkillStore';
 import Setting from './Setting';
+import { Button } from '../ui/button';
 
 const categories = [
     "Languages",
@@ -35,6 +36,8 @@ const Skills = () => {
         icons: selectedIcons,
         iconHeight,
         alignment,
+        layout,
+        setLayout,
         addIcon,
         setSelectedProvider,
         setSelectedStyle,
@@ -65,6 +68,15 @@ const Skills = () => {
         return skills[selectedCategory as keyof typeof skills] || [];
     }, [selectedProvider, selectedCategory]);
 
+    const isSelected = (layoutId: string) => {
+        return layout === layoutId || (!layout && layoutId === 'Layout-1');
+    };
+
+    const layouts = [
+        { id: 'Layout-1', name: 'Layout-1' },
+        { id: 'Layout-2', name: 'Layout-2' },
+    ];
+
     return (
         <Tabs defaultValue="select" className='w-full  '>
             <TabsList className="grid w-full grid-cols-2 gap-4 rounded-lg h-12 px-2">
@@ -73,6 +85,19 @@ const Skills = () => {
             </TabsList>
 
             <TabsContent value="select">
+
+                <CardContent className=" flex justify-start items-center p-0 my-4 gap-4">
+                    {layouts.map((layoutOption) => (
+                        <Button
+                            variant={isSelected(layoutOption.id) ? 'default' : 'outline'}
+                            key={layoutOption.id}
+                            onClick={() => setLayout(layoutOption.id as 'Layout-1' | 'Layout-2')}
+                        >
+                            {layoutOption.name}
+                        </Button>
+                    ))}
+                </CardContent>
+
                 <Card className='w-full p-4 flex flex-col border border-gray-200 rounded-lg shadow-sm'>
                     <CardTitle>Skills</CardTitle>
                     <CardContent className='p-0 mt-2'>
@@ -132,6 +157,7 @@ const Skills = () => {
                                                     alt={skill.label}
                                                     className='min-w-16 min-h-7 rounded-md'
                                                     style={{ height: iconHeight }}
+                                                    loading='lazy'
                                                 />
                                                 <TooltipContent className='mb-2 text-primary w-full shadow-lg border font-semibold'>
                                                     <p>{skill.label}</p>

--- a/components/ProfilePreview.tsx
+++ b/components/ProfilePreview.tsx
@@ -31,7 +31,9 @@ const ProfilePreview = () => {
     icons: skillIcons,
     iconHeight: skillIconHeight,
     gap: skillIconsGap,
-    alignment
+    alignment,
+    selectedProvider,
+    layout: SkillLayout,
   } = useSkillsStore();
 
   const {
@@ -85,11 +87,13 @@ const ProfilePreview = () => {
       </div>
     );
   };
+  const iconsPerRow = 6;
 
   return (
     <div className='flex flex-col justify-start items-center bg-card p-6 h-full overflow-scroll scrollbar-hide border border-gray-300 w-full shadow-lg rounded-lg'>
       <div className='h-full w-full  border-none'>
         <h1 className='text-2xl font-bold mb-4'>Profile Preview</h1>
+
         <div className='mt-2 pb-8 space-y-6'>
           {headerImage && (
             <div className='text-center'>
@@ -131,12 +135,12 @@ const ProfilePreview = () => {
                   href={icon.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className='transition transform hover:scale-105'
+                  className='transition transform '
                 >
                   <img
                     src={icon.url}
                     alt='social'
-                    className='rounded-md shadow-md'
+                    className='rounded-md '
                     style={{ height: `${heightValues[socialIconHeight]}px` }}
                   />
                 </a>
@@ -144,13 +148,11 @@ const ProfilePreview = () => {
             </div>
           </div>
 
-
           {aboutMe && (
             <div className='text-center'>
               {applyStyle(aboutMe, fieldStyles.aboutMe)}
             </div>
           )}
-
 
           {(currentlyDoing.working || currentlyDoing.learning || currentlyDoing.askMeAbout || currentlyDoing.funFact || currentlyDoing.portfolio || currentlyDoing.blog) && (
             <div className='text-left'>
@@ -190,7 +192,11 @@ const ProfilePreview = () => {
             </div>
           )}
 
+        </div>
 
+
+
+        {SkillLayout === "Layout-1" && (
           <div className='text-left'>
             <h3 className='font-bold text-xl mb-2'>Skills:</h3>
             <div
@@ -216,50 +222,87 @@ const ProfilePreview = () => {
               ))}
             </div>
           </div>
+        )}
 
-
-
-          <div className='flex flex-col w-full justify-start items-center '>
-            <h2 className='font-bold text-xl mb-2 self-start'>GitHub Stats</h2>
-            <div className='grid grid-cols-2 w-full gap-x-2 gap-y-3'>
-              {cards.map((card, index) => (
-                <img
-                  key={`${index}-${forceUpdate}`}
-                  src={getCardSrc(card)}
-                  alt={`GitHub ${card.type} Card`}
-                  style={{ maxWidth: '100%', height: 'auto' }}
-                />
-              ))}
-            </div>
+        {SkillLayout === "Layout-2" && (
+          <div className="w-full mb-4">
+            <h3 className="font-bold text-xl mb-2">Skills:</h3>
+            <table className="w-full table-auto border-collapse">
+              <tbody>
+                {Array(Math.ceil(skillIcons.length / iconsPerRow))
+                  .fill(0)
+                  .map((_, rowIndex) => (
+                    <tr key={rowIndex}>
+                      {skillIcons
+                        .slice(rowIndex * iconsPerRow, (rowIndex + 1) * iconsPerRow)
+                        .map((icon) => (
+                          <td
+                            key={icon.id}
+                            className="px-2 py-4 text-center border border-gray-300"
+                          >
+                            <div
+                              style={{
+                                display: "grid", // Set the div inside the td as a grid
+                                placeItems: `center center`, // Align both horizontally and vertically
+                              }}
+                            >
+                              <img
+                                src={icon.url}
+                                alt={icon.label}
+                                className="rounded-md"
+                                style={{ height: `${heightValues[skillIconHeight]}px` }}
+                              />
+                            </div>
+                          </td>
+                        ))}
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
           </div>
+        )}
 
 
-          <div className='text-left'>
-            <h3 className='font-bold text-xl mb-2'>Support Me:</h3>
-            <div
-              className='flex flex-wrap'
-              style={{
-                columnGap: `${gapValues[SupportIconGap]}px`,
-                rowGap: "6px",
-                justifyContent: SupportAlignment,
-              }}
-            >
-              {SupportIcons.map((icon, index) => (
-                <a
-                  key={index}
-                  href={icon.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className='transition transform hover:scale-105'
-                >
-                  <img
-                    src={icon.url}
-                    className='rounded-md shadow-md'
-                    style={{ height: `${heightValues[SupportIconsHeight]}px` }}
-                  />
-                </a>
-              ))}
-            </div>
+        <div className='flex flex-col w-full justify-start items-center '>
+          <h2 className='font-bold text-xl mb-2 self-start'>GitHub Stats</h2>
+          <div className='grid grid-cols-2 w-full gap-x-2 gap-y-3'>
+            {cards.map((card, index) => (
+              <img
+                key={`${index}-${forceUpdate}`}
+                src={getCardSrc(card)}
+                alt={`GitHub ${card.type} Card`}
+                style={{ maxWidth: '100%', height: 'auto' }}
+              />
+            ))}
+          </div>
+        </div>
+
+
+        <div className='text-left'>
+          <h3 className='font-bold text-xl mb-2'>Support Me:</h3>
+          <div
+            className='flex flex-wrap'
+            style={{
+              columnGap: `${gapValues[SupportIconGap]}px`,
+              rowGap: "6px",
+              justifyContent: SupportAlignment,
+            }}
+          >
+            {SupportIcons.map((icon, index) => (
+              <a
+                key={index}
+                href={icon.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className='transition transform hover:scale-105'
+              >
+                <img
+                  src={icon.url}
+                  className='rounded-md shadow-md'
+                  style={{ height: `${heightValues[SupportIconsHeight]}px` }}
+                />
+              </a>
+            ))}
           </div>
         </div>
       </div>

--- a/data/IntroData.ts
+++ b/data/IntroData.ts
@@ -1,0 +1,22 @@
+export const Banners = [
+    "https://user-images.githubusercontent.com/10498744/210012254-234538ff-d198-48aa-8964-37e6fd45d227.gif",
+    "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/c83c004e-1370-4756-88e5-4071de797088/dgdq8br-09cc7ad6-a021-47a5-b0e0-917b12b0f7a7.gif?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcL2M4M2MwMDRlLTEzNzAtNDc1Ni04OGU1LTQwNzFkZTc5NzA4OFwvZGdkcThici0wOWNjN2FkNi1hMDIxLTQ3YTUtYjBlMC05MTdiMTJiMGY3YTcuZ2lmIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.tqRMtE-b2QiI2nnefNxSDMJvZCcYqFmq2ccg_Xfzqb8",
+    "https://static.wixstatic.com/media/53fad0_ce0704caa0174d6aa9b2b8101a62fa77~mv2.gif",
+    "https://user-images.githubusercontent.com/74038190/215768208-3bf3dda8-eeea-40ee-a58b-f5ac529685bf.gif",
+    "https://cdna.artstation.com/p/assets/images/images/066/880/442/original/ilgin-gungor-calisma-masasi11.gif?1694002774",
+    "https://globaleducation.s3.ap-south-1.amazonaws.com/globaledu/gif/front-end-development.gif",
+    "https://private-user-images.githubusercontent.com/74038190/243078834-72903324-cf57-4e90-80a6-ed3c9734e0ed.gif?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjcyNzA2ODcsIm5iZiI6MTcyNzI3MDM4NywicGF0aCI6Ii83NDAzODE5MC8yNDMwNzg4MzQtNzI5MDMzMjQtY2Y1Ny00ZTkwLTgwYTYtZWQzYzk3MzRlMGVkLmdpZj9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA5MjUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwOTI1VDEzMTk0N1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWFiMzQ0MDY3OGNlNjBlOWMzNjNmMzM0MTAzYzFhNWY0NTM3M2U5YmM2ZDUwODBlNjNkYzE2MzY3YTQ0ZDZhM2YmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.zvZP1jlY_Aiu_QqmtYhfivhG32o8wjD0Wi30um30vuY",
+    "https://user-images.githubusercontent.com/74038190/213910845-af37a709-8995-40d6-be59-724526e3c3d7.gif",
+    "https://miro.medium.com/v2/resize:fit:1358/0*FGD6BUzzZs1VJLuY.gif",
+    "https://mir-s3-cdn-cf.behance.net/project_modules/max_1200/79731568097599.5b50bca477735.jpg",
+    "https://www.cloudtransformation.com.sg/wp-content/uploads/2018/08/banner-softwaredev.jpg",
+    "https://scrimba.com/articles/content/images/size/w2000/2022/08/Coding-or-Programming_-What-Is-the-Difference_-main-1.png",
+    "https://www.codecademy.com/resources/blog/wp-content/uploads/2022/12/What-is-collaborative-coding--1.png",
+    "https://www.codecademy.com/resources/blog/wp-content/uploads/2022/12/Websites-Software-Programmers-Thumbnails_1200x558.png?w=1024",
+    "https://www.codecademy.com/resources/blog/wp-content/uploads/2022/12/What-Is-Pair-Programming--1.png",
+    "https://railsware.com/blog/wp-content/uploads/2021/11/featured_image.jpg",
+    "https://www.21kschool.com/ng/wp-content/uploads/sites/28/2024/02/Learn-to-code-4-reasons-why-your-child-should-do-it.png",
+    "https://www.21kschool.com/ng/wp-content/uploads/sites/28/2024/02/Coding-websites-for-kids-practice-your-coding-skills.png", ,
+    "https://www.21kschool.com/za/wp-content/uploads/sites/23/2024/03/What-Is-Block-Coding-For-Kids_Guide-To-Get-Started-With-Learning-Block-Coding.jpg",
+    "https://as2.ftcdn.net/v2/jpg/05/67/40/31/1000_F_567403147_WjV5fqGRjjPUkBOnXaaREKgVjZMC12M7.jpg"
+]

--- a/store/SkillStore.tsx
+++ b/store/SkillStore.tsx
@@ -7,6 +7,9 @@ type Skill = {
     url: string
 }
 
+type Layout = 'Layout-1' | 'Layout-2';
+
+
 type SkillsStore = {
     selectedProvider: string;
     selectedStyle: string;
@@ -15,6 +18,8 @@ type SkillsStore = {
     iconHeight: HeightType;
     gap: GapType;
     alignment: AlignmentType;
+    layout: Layout;
+    setLayout: (layout: Layout) => void;
     setSelectedProvider: (provider: string) => void;
     setSelectedStyle: (style: string) => void;
     setSelectedCategory: (category: string) => void;
@@ -34,6 +39,8 @@ const useSkillsStore = create<SkillsStore>((set) => ({
     iconHeight: 'sm',
     gap: 'xs',
     alignment: 'left',
+    layout: 'Layout-1' as Layout,
+    setLayout: (layout) => set({ layout }),
     setSelectedProvider: (provider) => set(() => ({ selectedProvider: provider })),
     setSelectedStyle: (style) => set(() => ({ selectedStyle: style })),
     setSelectedCategory: (category) => set(() => ({ selectedCategory: category })),


### PR DESCRIPTION
### Changes

**1. globals.css:**

- Removed unnecessary @layer base styles for borders and background.
- Added a .scrollbar-hide class for hiding scrollbars on webkit and other browsers.
- Introduced .dropdown styles with overflow-y: auto and will-change: scroll-position for smoother scrolling.

**2. Updates in MarkdownGenerator:**

- Added support for dynamic layouts (Layout-1 and Layout-2) in the skills section.
- Conditional rendering of skill icons either in a flex container or a table based on the selected layout.
- Improved responsiveness by setting different numbers of icons per row depending on the layout and provider (e.g., shields.io).

**3. Changes in ProfileForm/Introduction:**

- Introduced a new dropdown selection for header images using a predefined list of banners (Banners).
- Implemented a stateful dropdown system to select a banner.
- Added support for dynamically rendering banners in the UI.

**4. Changes in ProfileForm/Skills:**

- Introduced layout selection (Layout-1, Layout-2) for skills, along with a state handler for managing the layout.
- Buttons to toggle between layouts.
- Updated rendering of skills based on the selected layout.

**5. Changes in ProfilePreview.tsx:**

- Updated the preview of skills with support for Layout-1 (flex) and Layout-2 (table-based grid).
- Adjusted the structure of GitHub stats and "Support Me" sections with more grid-based layout logic for better alignment and responsiveness.

**6. New data in IntroData.ts:**

- A predefined list of banner URLs was added to handle the header image selection for the profile preview.